### PR TITLE
Updated DMD option passing for latest DMD master

### DIFF
--- a/source/worker.d
+++ b/source/worker.d
@@ -8,6 +8,7 @@ import dmd.errors;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.globals;
+import dmd.target;
 import dmd.identifier;
 import dmd.id;
 import dmd.dmodule;
@@ -145,12 +146,12 @@ void nogcCoverageCheck(Dsymbol dsym, Scope* sc)
 
 void initTool(string[] versionIdentifiers, string[] importPaths)
 {
+    auto enabled = FeatureState.enabled;
     //Global.params must be set *before* initDMD();
-    global.params.isLinux = true;
-    global.params.is64bit = (size_t.sizeof == 8);
+    target.os = Target.OS.linux;
     global.params.useUnitTests = true;
-    global.params.useDIP25 = true;
-    global.params.vsafe = true;
+    global.params.useDIP25 = enabled;
+    global.params.useDIP1000 = enabled;
 
     initDMD(null, versionIdentifiers);
 


### PR DESCRIPTION
There is a plan at Phobos strike team to use your work to improve the documentation. DMD compiler flag API has changed though - this changes nogc-cov accordingly.